### PR TITLE
Add script generating HTML offers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated HTML file
+offres.html
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# agency-mode-
+# Job Offers HTML Generator
+
+This project demonstrates a small script that converts a list of job offers
+into an HTML page. It includes a `save_html` function that escapes job snippets
+using `html.escape` to avoid injecting HTML tags into the output file.
+
+Run the script with `python3 main.py` to generate `offres.html` using the
+sample data.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+import html
+
+sample_jobs = [
+    {
+        "title": "Développeur Python",
+        "link": "https://example.com/python-dev",
+        "snippet": "<p>Développer des applications web.</p>",
+        "salary": "45k€"
+    },
+    {
+        "title": "Data Scientist",
+        "link": "https://example.com/data-scientist",
+        "snippet": "<p>Analyse de données et machine learning.</p>",
+        "salary": "50k€"
+    }
+]
+
+def save_html(jobs, output_file="offres.html"):
+    """Save job offers to an HTML file."""
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write("<html><head><meta charset='utf-8'><title>Offres</title></head><body>\n")
+        for j in jobs:
+            f.write("<div class='job'>\n")
+            f.write(f"  <a href='{html.escape(j['link'])}'><h2>{html.escape(j['title'])}</h2></a>\n")
+            snippet = html.escape(j['snippet'][:300])
+            f.write(f"  <p>{snippet}</p>\n")
+            if j.get('salary'):
+                f.write(f"  <p><strong>Salaire:</strong> {html.escape(j['salary'])}</p>\n")
+            f.write("</div>\n")
+        f.write("</body></html>\n")
+
+if __name__ == "__main__":
+    save_html(sample_jobs)
+    print("Generated offres.html")


### PR DESCRIPTION
## Summary
- add a Python script with `save_html` that escapes snippets using html.escape
- add README with instructions
- ignore generated HTML file in `.gitignore`

## Testing
- `python3 main.py`

------
https://chatgpt.com/codex/tasks/task_e_6869860439e88323bd703fc04c571d09